### PR TITLE
Add HummingbirdAuthXCT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         ]),
         .target(name: "HummingbirdAuthXCT", dependencies: [
             .byName(name: "HummingbirdAuth"),
+            .product(name: "HummingbirdXCT", package: "hummingbird"),
         ]),
         .target(name: "CBcrypt", dependencies: []),
         .testTarget(name: "HummingbirdAuthTests", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,10 @@ let package = Package(
     platforms: [.macOS(.v10_15), .iOS(.v12), .tvOS(.v12)],
     products: [
         .library(name: "HummingbirdAuth", targets: ["HummingbirdAuth"]),
+        .library(name: "HummingbirdAuthXCT", targets: ["HummingbirdAuthXCT"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "0.11.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "0.11.3"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", .upToNextMinor(from: "0.7.0")),
     ],
@@ -21,9 +22,13 @@ let package = Package(
             .product(name: "ExtrasBase64", package: "swift-extras-base64"),
             .product(name: "Hummingbird", package: "hummingbird"),
         ]),
+        .target(name: "HummingbirdAuthXCT", dependencies: [
+            .byName(name: "HummingbirdAuth"),
+        ]),
         .target(name: "CBcrypt", dependencies: []),
         .testTarget(name: "HummingbirdAuthTests", dependencies: [
             .byName(name: "HummingbirdAuth"),
+            .byName(name: "HummingbirdAuthXCT"),
             .product(name: "HummingbirdXCT", package: "hummingbird"),
         ]),
     ]

--- a/Sources/HummingbirdAuthXCT/XCT+Auth.swift
+++ b/Sources/HummingbirdAuthXCT/XCT+Auth.swift
@@ -17,6 +17,7 @@ import Hummingbird
 import HummingbirdXCT
 import XCTest
 
+/// Used to generate various authentication types for XCT tests
 public struct HBXCTAuthentication: Equatable {
     /// create basic authentication test
     public static func basic(username: String, password: String) -> Self {
@@ -71,7 +72,7 @@ public struct HBXCTAuthentication: Equatable {
 }
 
 extension HBApplication {
-    /// Send request and call test callback on the response returned
+    /// Send request with authentication and call test callback on the response returned
     public func XCTExecute(
         uri: String,
         method: HTTPMethod,

--- a/Sources/HummingbirdAuthXCT/XCT+Auth.swift
+++ b/Sources/HummingbirdAuthXCT/XCT+Auth.swift
@@ -22,17 +22,19 @@ public struct HBXCTAuthentication: Equatable {
     public static func basic(username: String, password: String) -> Self {
         return .init(value: .basic(username: username, password: password))
     }
+
     /// create bearer authentication test
     public static func bearer(_ token: String) -> Self {
         return .init(value: .bearer(token))
     }
+
     /// create cookie authentication test
     public static func cookie(name: String, value: String) -> Self {
         return .init(value: .cookie(name: name, value: value))
     }
 
     func apply(uri: String, method: HTTPMethod, headers: HTTPHeaders, body: ByteBuffer?) -> (uri: String, method: HTTPMethod, headers: HTTPHeaders, body: ByteBuffer?) {
-        switch value {
+        switch self.value {
         case .basic(let username, let password):
             var headers = headers
             let usernamePassword = "\(username):\(password)"
@@ -55,7 +57,6 @@ public struct HBXCTAuthentication: Equatable {
             }
             headers.replaceOrAdd(name: "cookie", value: newCookie)
             return (uri: uri, method: method, headers: headers, body: body)
-
         }
     }
 
@@ -67,7 +68,6 @@ public struct HBXCTAuthentication: Equatable {
     }
 
     private let value: Internal
-
 }
 
 extension HBApplication {
@@ -90,5 +90,4 @@ extension HBApplication {
             try testCallback(response)
         }.wait())
     }
-
 }

--- a/Sources/HummingbirdAuthXCT/XCT+Auth.swift
+++ b/Sources/HummingbirdAuthXCT/XCT+Auth.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ExtrasBase64
+import Hummingbird
+import HummingbirdXCT
+import XCTest
+
+public struct HBXCTAuthentication: Equatable {
+    /// create basic authentication test
+    public static func basic(username: String, password: String) -> Self {
+        return .init(value: .basic(username: username, password: password))
+    }
+    /// create bearer authentication test
+    public static func bearer(_ token: String) -> Self {
+        return .init(value: .bearer(token))
+    }
+    /// create cookie authentication test
+    public static func cookie(name: String, value: String) -> Self {
+        return .init(value: .cookie(name: name, value: value))
+    }
+
+    func apply(uri: String, method: HTTPMethod, headers: HTTPHeaders, body: ByteBuffer?) -> (uri: String, method: HTTPMethod, headers: HTTPHeaders, body: ByteBuffer?) {
+        switch value {
+        case .basic(let username, let password):
+            var headers = headers
+            let usernamePassword = "\(username):\(password)"
+            let authorization = "Basic \(String(base64Encoding: usernamePassword.utf8))"
+            headers.replaceOrAdd(name: "authorization", value: authorization)
+            return (uri: uri, method: method, headers: headers, body: body)
+
+        case .bearer(let token):
+            var headers = headers
+            headers.replaceOrAdd(name: "authorization", value: "Bearer \(token)")
+            return (uri: uri, method: method, headers: headers, body: body)
+
+        case .cookie(let name, let value):
+            var headers = headers
+            let newCookie: String
+            if let cookie = headers["cookie"].first {
+                newCookie = "\(name)=\(value); \(cookie)"
+            } else {
+                newCookie = "\(name)=\(value)"
+            }
+            headers.replaceOrAdd(name: "cookie", value: newCookie)
+            return (uri: uri, method: method, headers: headers, body: body)
+
+        }
+    }
+
+    /// Internal type
+    private enum Internal: Equatable {
+        case basic(username: String, password: String)
+        case bearer(String)
+        case cookie(name: String, value: String)
+    }
+
+    private let value: Internal
+
+}
+
+extension HBApplication {
+    /// Send request and call test callback on the response returned
+    public func XCTExecute(
+        uri: String,
+        method: HTTPMethod,
+        headers: HTTPHeaders = [:],
+        auth: HBXCTAuthentication,
+        body: ByteBuffer? = nil,
+        testCallback: @escaping (HBXCTResponse) throws -> Void
+    ) {
+        let request = auth.apply(uri: uri, method: method, headers: headers, body: body)
+        XCTAssertNoThrow(try self.xct.execute(
+            uri: request.uri,
+            method: request.method,
+            headers: request.headers,
+            body: request.body
+        ).flatMapThrowing { response in
+            try testCallback(response)
+        }.wait())
+    }
+
+}


### PR DESCRIPTION
Allows tests to add authentication methods to XCTExecute
Also fixed testMultipleBcrypt to avoid using AsyncHTTPClient