### PR TITLE
HBRequest as a struct

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "HummingbirdAuthXCT", targets: ["HummingbirdAuthXCT"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "0.11.3"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", .upToNextMinor(from: "0.7.0")),
     ],

--- a/Sources/HummingbirdAuth/Authenticator/Authenticator.swift
+++ b/Sources/HummingbirdAuth/Authenticator/Authenticator.swift
@@ -67,8 +67,9 @@ extension HBAuthenticator {
     public func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
         authenticate(request: request)
             .flatMap { authenticated in
+                var request = request
                 if let authenticated = authenticated {
-                    request.auth.login(authenticated)
+                    request.authLogin(authenticated)
                 }
                 return next.respond(to: request)
             }

--- a/Sources/HummingbirdAuth/BasicAuthentication.swift
+++ b/Sources/HummingbirdAuth/BasicAuthentication.swift
@@ -21,11 +21,11 @@ public struct BasicAuthentication {
     public let password: String
 }
 
-extension HBRequest.Auth {
+extension HBRequest {
     /// Return Basic (username/password) authorization information from request
     public var basic: BasicAuthentication? {
         // check for authorization header
-        guard let authorization = request.headers["Authorization"].first else { return nil }
+        guard let authorization = self.headers["Authorization"].first else { return nil }
         // check for basic prefix
         guard authorization.hasPrefix("Basic ") else { return nil }
         // extract base64 data

--- a/Sources/HummingbirdAuth/BasicAuthentication.swift
+++ b/Sources/HummingbirdAuth/BasicAuthentication.swift
@@ -23,7 +23,7 @@ public struct BasicAuthentication {
 
 extension HBRequest {
     /// Return Basic (username/password) authorization information from request
-    public var basic: BasicAuthentication? {
+    public var authBasic: BasicAuthentication? {
         // check for authorization header
         guard let authorization = self.headers["Authorization"].first else { return nil }
         // check for basic prefix

--- a/Sources/HummingbirdAuth/BearerAuthentication.swift
+++ b/Sources/HummingbirdAuth/BearerAuthentication.swift
@@ -19,11 +19,11 @@ public struct BearerAuthentication {
     public let token: String
 }
 
-extension HBRequest.Auth {
+extension HBRequest {
     /// Return Bearer authorization information from request
     public var bearer: BearerAuthentication? {
         // check for authorization header
-        guard let authorization = request.headers["Authorization"].first else { return nil }
+        guard let authorization = self.headers["Authorization"].first else { return nil }
         // check for bearer prefix
         guard authorization.hasPrefix("Bearer ") else { return nil }
         // return token

--- a/Sources/HummingbirdAuth/BearerAuthentication.swift
+++ b/Sources/HummingbirdAuth/BearerAuthentication.swift
@@ -21,7 +21,7 @@ public struct BearerAuthentication {
 
 extension HBRequest {
     /// Return Bearer authorization information from request
-    public var bearer: BearerAuthentication? {
+    public var authBearer: BearerAuthentication? {
         // check for authorization header
         guard let authorization = self.headers["Authorization"].first else { return nil }
         // check for bearer prefix

--- a/Tests/HummingbirdAuthTests/AuthTests.swift
+++ b/Tests/HummingbirdAuthTests/AuthTests.swift
@@ -55,7 +55,7 @@ final class AuthTests: XCTestCase {
     func testBearer() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get { request -> String? in
-            return request.bearer?.token
+            return request.authBearer?.token
         }
         try app.XCTStart()
         defer { app.XCTStop() }
@@ -72,7 +72,7 @@ final class AuthTests: XCTestCase {
     func testBasic() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get { request -> String? in
-            return request.basic.map { "\($0.username):\($0.password)" }
+            return request.authBasic.map { "\($0.username):\($0.password)" }
         }
         try app.XCTStart()
         defer { app.XCTStop() }

--- a/Tests/HummingbirdAuthTests/AuthTests.swift
+++ b/Tests/HummingbirdAuthTests/AuthTests.swift
@@ -55,7 +55,7 @@ final class AuthTests: XCTestCase {
     func testBearer() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get { request -> String? in
-            return request.auth.bearer?.token
+            return request.bearer?.token
         }
         try app.XCTStart()
         defer { app.XCTStop() }
@@ -72,7 +72,7 @@ final class AuthTests: XCTestCase {
     func testBasic() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get { request -> String? in
-            return request.auth.basic.map { "\($0.username):\($0.password)" }
+            return request.basic.map { "\($0.username):\($0.password)" }
         }
         try app.XCTStart()
         defer { app.XCTStop() }
@@ -89,12 +89,13 @@ final class AuthTests: XCTestCase {
         }
         let app = HBApplication(testing: .embedded)
         app.router.get { request -> HTTPResponseStatus in
-            request.auth.login(User(name: "Test"))
-            XCTAssert(request.auth.has(User.self))
-            XCTAssertEqual(request.auth.get(User.self)?.name, "Test")
-            request.auth.logout(User.self)
-            XCTAssertFalse(request.auth.has(User.self))
-            XCTAssertNil(request.auth.get(User.self))
+            var request = request
+            request.authLogin(User(name: "Test"))
+            XCTAssert(request.authHas(User.self))
+            XCTAssertEqual(request.authGet(User.self)?.name, "Test")
+            request.authLogout(User.self)
+            XCTAssertFalse(request.authHas(User.self))
+            XCTAssertNil(request.authGet(User.self))
             return .accepted
         }
 
@@ -119,7 +120,7 @@ final class AuthTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.middleware.add(HBTestAuthenticator())
         app.router.get { request -> HTTPResponseStatus in
-            guard request.auth.has(User.self) else { return .unauthorized }
+            guard request.authHas(User.self) else { return .unauthorized }
             return .ok
         }
 


### PR DESCRIPTION
HBRequest being a struct affects Auth package considerably.
As Auth changes the request ie caching logged in entities on the request it cannot do this via a separate object anymore.
This means the auth apis are now at the the HBRequest level and some are mutating (login/logout).

`HBRequest.auth.login` is now `HBRequest.authLogin`
`HBRequest.auth.logout` is now `HBRequest.authLogout`

I have replicated this change across all the Auth apis