### PR TITLE
2.x.x - Rename AuthRequestContexts

### DIFF
--- a/Sources/HummingbirdAuth/Authenticator/AuthRequestContext.swift
+++ b/Sources/HummingbirdAuth/Authenticator/AuthRequestContext.swift
@@ -18,13 +18,13 @@ import NIOCore
 
 /// Protocol that all request contexts should conform to if they want to support
 /// authentication middleware
-public protocol HBAuthRequestContextProtocol: HBRequestContext {
+public protocol HBAuthRequestContext: HBRequestContext {
     /// Login cache
     var auth: HBLoginCache { get set }
 }
 
 /// Implementation of a basic request context that supports everything the Hummingbird library needs
-public struct HBAuthRequestContext: HBAuthRequestContextProtocol {
+public struct HBBasicAuthRequestContext: HBAuthRequestContext {
     /// core context
     public var coreContext: HBCoreRequestContext
     /// Login cache

--- a/Sources/HummingbirdAuth/Authenticator/Authenticator.swift
+++ b/Sources/HummingbirdAuth/Authenticator/Authenticator.swift
@@ -55,7 +55,7 @@ public protocol HBAuthenticatable: Sendable {}
 ///     }
 /// }
 /// ```
-public protocol HBAuthenticator: HBMiddlewareProtocol where Context: HBAuthRequestContextProtocol {
+public protocol HBAuthenticator: HBMiddlewareProtocol where Context: HBAuthRequestContext {
     /// type to be authenticated
     associatedtype Value: HBAuthenticatable
     /// Called by middleware to see if request can authenticate.

--- a/Sources/HummingbirdAuth/Middleware/IsAuthenticateMiddleware.swift
+++ b/Sources/HummingbirdAuth/Middleware/IsAuthenticateMiddleware.swift
@@ -15,7 +15,7 @@
 import Hummingbird
 
 /// Middleware returning 404 for unauthenticated requests
-public struct IsAuthenticatedMiddleware<Auth: HBAuthenticatable, Context: HBAuthRequestContextProtocol>: HBMiddlewareProtocol {
+public struct IsAuthenticatedMiddleware<Auth: HBAuthenticatable, Context: HBAuthRequestContext>: HBMiddlewareProtocol {
     public init(_: Auth.Type) {}
 
     public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse { guard context.auth.has(Auth.self) else { throw HBHTTPError(.unauthorized) }

--- a/Tests/HummingbirdAuthTests/SessionTests.swift
+++ b/Tests/HummingbirdAuthTests/SessionTests.swift
@@ -24,13 +24,13 @@ final class SessionTests: XCTestCase {
         struct User: HBAuthenticatable {
             let name: String
         }
-        struct MySessionAuthenticator<Context: HBAuthRequestContextProtocol>: HBSessionAuthenticator {
+        struct MySessionAuthenticator<Context: HBAuthRequestContext>: HBSessionAuthenticator {
             let sessionStorage: HBSessionStorage
             func getValue(from session: Int, request: HBRequest, context: Context) async throws -> User? {
                 return User(name: "Adam")
             }
         }
-        let router = HBRouter(context: HBAuthRequestContext.self)
+        let router = HBRouter(context: HBBasicAuthRequestContext.self)
         let persist = HBMemoryPersistDriver()
         let sessions = HBSessionStorage(persist)
         router.put("session") { _, _ -> HBResponse in
@@ -64,7 +64,7 @@ final class SessionTests: XCTestCase {
             let name: String
         }
 
-        let router = HBRouter(context: HBAuthRequestContext.self)
+        let router = HBRouter(context: HBBasicAuthRequestContext.self)
         let persist = HBMemoryPersistDriver()
         let sessions = HBSessionStorage(persist)
         router.post("save") { request, _ -> HBResponse in
@@ -105,7 +105,7 @@ final class SessionTests: XCTestCase {
     }
 
     func testSessionUpdateError() async throws {
-        let router = HBRouter(context: HBAuthRequestContext.self)
+        let router = HBRouter(context: HBBasicAuthRequestContext.self)
         let persist = HBMemoryPersistDriver()
         let sessions = HBSessionStorage(persist)
 


### PR DESCRIPTION
This PR renames 
- `HBAuthRequestContextProtocol` to `HBAuthRequestContext` 
- `HBAuthRequestContext` to `HBBasicAuthRequestContext`

This is a breaking change but it is consistent with all the other request context types. 