### PR TITLE
Fix documentation for IsAuthenticatedMiddleware.

### DIFF
--- a/Sources/HummingbirdAuth/Middleware/IsAuthenticatedMiddleware.swift
+++ b/Sources/HummingbirdAuth/Middleware/IsAuthenticatedMiddleware.swift
@@ -14,7 +14,7 @@
 
 import Hummingbird
 
-/// Middleware returning 404 for unauthenticated requests
+/// Middleware returning 401 for unauthenticated requests
 public struct IsAuthenticatedMiddleware<Auth: Authenticatable, Context: AuthRequestContext>: RouterMiddleware {
     public init(_: Auth.Type) {}
 


### PR DESCRIPTION
The docs say the function returns a 404 when in reality it's a 401.

This commit also fixes the filename to match the middleware name.