### PR TITLE
Allow authentication with multiple objects.

### DIFF
--- a/Sources/HummingbirdAuth/Authenticator/LoginCache.swift
+++ b/Sources/HummingbirdAuth/Authenticator/LoginCache.swift
@@ -22,7 +22,7 @@ public struct LoginCache: Sendable {
     /// Login with authenticatable object. Add object to cache
     /// - Parameter auth: authentication details
     public mutating func login<Auth: Authenticatable>(_ auth: Auth) {
-        self.cache = [ObjectIdentifier(Auth.self): auth]
+        self.cache[ObjectIdentifier(Auth.self)] = auth
     }
 
     /// Logout authenticatable object. Removes object from cache

--- a/Tests/HummingbirdAuthTests/AuthTests.swift
+++ b/Tests/HummingbirdAuthTests/AuthTests.swift
@@ -118,15 +118,32 @@ final class AuthTests: XCTestCase {
         struct User: Authenticatable {
             let name: String
         }
+        struct Additional: Authenticatable {
+            let something: String
+        }
         let router = Router(context: BasicAuthRequestContext.self)
         router.get { _, context -> HTTPResponse.Status in
             var context = context
             context.auth.login(User(name: "Test"))
+            context.auth.login(Additional(something: "abc"))
+
             XCTAssert(context.auth.has(User.self))
             XCTAssertEqual(context.auth.get(User.self)?.name, "Test")
+            XCTAssert(context.auth.has(Additional.self))
+            XCTAssertEqual(context.auth.get(Additional.self)?.something, "abc")
+
             context.auth.logout(User.self)
             XCTAssertFalse(context.auth.has(User.self))
             XCTAssertNil(context.auth.get(User.self))
+            XCTAssert(context.auth.has(Additional.self))
+            XCTAssertEqual(context.auth.get(Additional.self)?.something, "abc")
+
+            context.auth.logout(Additional.self)
+            XCTAssertFalse(context.auth.has(User.self))
+            XCTAssertNil(context.auth.get(User.self))
+            XCTAssertFalse(context.auth.has(Additional.self))
+            XCTAssertNil(context.auth.get(Additional.self))
+
             return .accepted
         }
         let app = Application(responder: router.buildResponder())


### PR DESCRIPTION
It looks like this was actually the intent, and this makes the auth cache work similarly to Vapor's.