### PR TITLE
SessionAuthenticator

### DIFF
--- a/Sources/HummingbirdAuth/Deprecated.swift
+++ b/Sources/HummingbirdAuth/Deprecated.swift
@@ -26,7 +26,7 @@ public typealias HBLoginCache = LoginCache
 public typealias HBAuthenticatable = Authenticatable
 @_documentation(visibility: internal) @available(*, unavailable, renamed: "AuthenticatorMiddleware")
 public typealias HBAuthenticator = AuthenticatorMiddleware
-@_documentation(visibility: internal) @available(*, unavailable, renamed: "SessionMiddleware")
-public typealias HBSessionAuthenticator = SessionMiddleware
+@_documentation(visibility: internal) @available(*, unavailable, renamed: "SessionAuthenticator")
+public typealias HBSessionAuthenticator = SessionAuthenticator
 @_documentation(visibility: internal) @available(*, unavailable, renamed: "SessionStorage")
 public typealias HBSessionStorage = SessionStorage

--- a/Sources/HummingbirdAuth/Sessions/SessionAuthenticator.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionAuthenticator.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2022 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,27 +14,53 @@
 
 import Hummingbird
 
-/// Session authenticator
-public protocol SessionMiddleware: AuthenticatorMiddleware {
-    /// authenticable value
-    associatedtype Value = Value
-    /// session object
-    associatedtype Session: Codable
+public protocol SessionUserRepository: Sendable {
+    associatedtype User: Authenticatable
+    associatedtype UserID: Codable
+    associatedtype Context: RequestContext & AuthRequestContext
 
-    /// container for session objects
-    var sessionStorage: SessionStorage { get }
-
-    /// Convert Session object into authenticated user
-    /// - Parameters:
-    ///   - from: session
-    ///   - request: request being processed
-    /// - Returns: Future holding optional authenticated user
-    func getValue(from: Session, request: Request, context: Context) async throws -> Value?
+    func getUser(from id: UserID, context: Context) async throws -> User?
 }
 
-extension SessionMiddleware {
-    public func authenticate(request: Request, context: Context) async throws -> Value? {
-        guard let session: Session = try await self.sessionStorage.load(request: request) else { return nil }
-        return try await getValue(from: session, request: request, context: context)
+/// Implementation of SessionUserRepository that uses a closure
+public struct UserSessionClosure<UserID: Codable, Context: RequestContext & AuthRequestContext, User: Authenticatable>: SessionUserRepository {
+    let getUserClosure: @Sendable (UserID, Context) async throws -> User?
+
+    public func getUser(from id: UserID, context: Context) async throws -> User? {
+        try await self.getUserClosure(id, context)
+    }
+}
+
+/// Session authenticator
+public struct SessionAuthenticator<Context: RequestContext & AuthRequestContext, Repository: SessionUserRepository>: AuthenticatorMiddleware where Context == Repository.Context {
+    let users: Repository
+
+    /// container for session objects
+    let sessionStorage: SessionStorage
+
+    /// Initialize SessionAuthenticator middleware
+    /// - Parameters:
+    ///   - users: User repository
+    ///   - sessionStorage: session storage
+    public init(users: Repository, sessionStorage: SessionStorage) {
+        self.users = users
+        self.sessionStorage = sessionStorage
+    }
+
+    /// Initialize SessionAuthenticator middleware
+    /// - Parameters:
+    ///   - sessionStorage: session storage
+    ///   - getUser: Closure returning user type from session id
+    public init<Session: Codable, User: Authenticatable>(
+        sessionStorage: SessionStorage,
+        getUser: @escaping @Sendable (Session, Context) async throws -> User?
+    ) where Repository == UserSessionClosure<Session, Context, User> {
+        self.users = UserSessionClosure(getUserClosure: getUser)
+        self.sessionStorage = sessionStorage
+    }
+
+    public func authenticate(request: Request, context: Context) async throws -> Repository.User? {
+        guard let session: Repository.UserID = try await self.sessionStorage.load(request: request) else { return nil }
+        return try await self.users.getUser(from: session, context: context)
     }
 }

--- a/Sources/HummingbirdAuth/Sessions/SessionAuthenticator.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionAuthenticator.swift
@@ -24,8 +24,10 @@ public protocol SessionUserRepository: Sendable {
 
 /// Implementation of SessionUserRepository that uses a closure
 public struct UserSessionClosure<UserID: Codable, Context: RequestContext & AuthRequestContext, User: Authenticatable>: SessionUserRepository {
+    @usableFromInline
     let getUserClosure: @Sendable (UserID, Context) async throws -> User?
 
+    @inlinable
     public func getUser(from id: UserID, context: Context) async throws -> User? {
         try await self.getUserClosure(id, context)
     }
@@ -33,9 +35,11 @@ public struct UserSessionClosure<UserID: Codable, Context: RequestContext & Auth
 
 /// Session authenticator
 public struct SessionAuthenticator<Context: RequestContext & AuthRequestContext, Repository: SessionUserRepository>: AuthenticatorMiddleware where Context == Repository.Context {
+    @usableFromInline
     let users: Repository
 
     /// container for session objects
+    @usableFromInline
     let sessionStorage: SessionStorage
 
     /// Initialize SessionAuthenticator middleware
@@ -59,6 +63,7 @@ public struct SessionAuthenticator<Context: RequestContext & AuthRequestContext,
         self.sessionStorage = sessionStorage
     }
 
+    @inlinable
     public func authenticate(request: Request, context: Context) async throws -> Repository.User? {
         guard let session: Repository.UserID = try await self.sessionStorage.load(request: request) else { return nil }
         return try await self.users.getUser(from: session, context: context)

--- a/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2022 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+
+/// Session authenticator
+@available(*, deprecated, message: "Use SessionAuthenticator instead.")
+public protocol SessionMiddleware: AuthenticatorMiddleware {
+    /// authenticable value
+    associatedtype Value = Value
+    /// session object
+    associatedtype Session: Codable
+
+    /// container for session objects
+    var sessionStorage: SessionStorage { get }
+
+    /// Convert Session object into authenticated user
+    /// - Parameters:
+    ///   - from: session
+    ///   - request: request being processed
+    /// - Returns: Future holding optional authenticated user
+    func getValue(from: Session, request: Request, context: Context) async throws -> Value?
+}
+
+@available(*, deprecated, message: "Use SessionAuthenticator instead.")
+extension SessionMiddleware {
+    public func authenticate(request: Request, context: Context) async throws -> Value? {
+        guard let session: Session = try await self.sessionStorage.load(request: request) else { return nil }
+        return try await getValue(from: session, request: request, context: context)
+    }
+}


### PR DESCRIPTION
Instead of being a protocol the authenticator is a struct the takes a repository generic parameter which converts between user id and user. This works in a similar manner to the BasicAuthenticator in #48 

You can set this up with either a Repository type or just a simple closure
```swift
struct UserRepository {
    let fluent: Fluent
    func getUser(from id: UUID, context: BasicAuthRequestContext) async throws -> User? {
        return User.find(id, on: fluent.db())
    }
}
router.add(middleware: SessionAuthenticator(userRepository: UserRepository (), sessionStorage: sessionStorage)
```

```swift
router.add(middleware: SessionAuthenticator(sessionStorage: sessionStorage) { (id: UUID, _) in
    return User.find(id, on: fluent.db())
}
```