### PR TITLE
Replace Context from SessionUserRepository call with Logger

### DIFF
--- a/Tests/HummingbirdAuthTests/SessionTests.swift
+++ b/Tests/HummingbirdAuthTests/SessionTests.swift
@@ -16,6 +16,7 @@ import Hummingbird
 import HummingbirdAuth
 import HummingbirdAuthTesting
 import HummingbirdTesting
+import Logging
 import NIOPosix
 import XCTest
 
@@ -30,7 +31,7 @@ final class SessionTests: XCTestCase {
 
             static let testSessionId = 89
 
-            func getUser(from id: UserID, context: BasicAuthRequestContext) async throws -> User? {
+            func getUser(from id: UserID, logger: Logger) async throws -> User? {
                 let user = self.users[id]
                 return user
             }


### PR DESCRIPTION
When using this in the examples I found including the Context in the SessionUserRepository was complicating things. By adding additional generic parameters in areas where they weren't needed. This PR removes the context but leaves a Logger to be used