### PR TITLE
Add testInvalidSession

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "HummingbirdAuthTesting", targets: ["HummingbirdAuthTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "persist-invalid-conversion"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "HummingbirdAuthTesting", targets: ["HummingbirdAuthTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.4.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "persist-invalid-conversion"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),

--- a/Tests/HummingbirdAuthTests/SessionTests.swift
+++ b/Tests/HummingbirdAuthTests/SessionTests.swift
@@ -218,7 +218,7 @@ final class SessionTests: XCTestCase {
                     domain: "https://test.com",
                     path: "/test",
                     secure: true,
-                    sameSite: .secure
+                    sameSite: .strict
                 )
             )
         )
@@ -242,7 +242,7 @@ final class SessionTests: XCTestCase {
                 XCTAssertEqual(cookie.domain, "https://test.com")
                 XCTAssertEqual(cookie.path, "/test")
                 XCTAssertEqual(cookie.secure, true)
-                XCTAssertEqual(cookie.sameSite, .secure)
+                XCTAssertEqual(cookie.sameSite, .strict)
             }
         }
     }
@@ -266,6 +266,10 @@ final class SessionTests: XCTestCase {
         try await app.test(.router) { client in
             try await client.execute(uri: "/test", method: .post, headers: [.cookie: cookie.description]) { response in
                 XCTAssertEqual(response.status, .noContent)
+                let setCookieHeader = try XCTUnwrap(response.headers[.setCookie])
+                let cookie = Cookie(from: setCookieHeader[...])
+                let expires = try XCTUnwrap(cookie?.expires)
+                XCTAssertLessThanOrEqual(expires, .now)
             }
         }
     }


### PR DESCRIPTION
Add sessionInvalidType error
If SessionMiddleware receives `sessionInvalidType` error then ignore session and expire the cookie.