### PR TITLE
Adding AuthZ support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
     products: [
         .library(name: "HummingbirdAuth", targets: ["HummingbirdAuth"]),
+        .library(name: "HummingbirdAuthorization", targets: ["HummingbirdAuthorization"]),
         .library(name: "HummingbirdBasicAuth", targets: ["HummingbirdBasicAuth"]),
         .library(name: "HummingbirdBcrypt", targets: ["HummingbirdBcrypt"]),
         .library(name: "HummingbirdOTP", targets: ["HummingbirdOTP"]),
@@ -20,6 +21,13 @@ let package = Package(
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),
     ],
     targets: [
+        .target(
+            name: "HummingbirdAuthorization",
+            dependencies: [
+                .byName(name: "HummingbirdAuth"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ]
+        ),
         .target(
             name: "HummingbirdAuth",
             dependencies: [
@@ -60,6 +68,7 @@ let package = Package(
             name: "HummingbirdAuthTests",
             dependencies: [
                 .byName(name: "HummingbirdAuth"),
+                .byName(name: "HummingbirdAuthorization"),
                 .byName(name: "HummingbirdBasicAuth"),
                 .byName(name: "HummingbirdBcrypt"),
                 .byName(name: "HummingbirdOTP"),

--- a/Sources/HummingbirdAuthorization/AuthorizationPolicy.swift
+++ b/Sources/HummingbirdAuthorization/AuthorizationPolicy.swift
@@ -1,0 +1,70 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// Protocol for authorization policies.
+///
+/// An `AuthorizationPolicy` determines whether an authenticated identity is allowed
+/// to proceed with a given request. Policies are evaluated *after* authentication —
+/// the identity is already resolved in the request context.
+///
+/// Implement this protocol to create reusable, composable authorization rules.
+/// For one-off rules, use ``ClosureAuthorizationPolicy``.
+///
+/// Policies can be composed using ``AllOf``, ``AnyOf``, and ``Not`` combinators:
+///
+/// ```swift
+/// IsAuthorizedMiddleware(
+///     AnyOf(
+///         RolePolicy("admin"),
+///         AllOf(RolePolicy("editor"), PermissionPolicy("posts:publish"))
+///     )
+/// )
+/// ```
+public protocol AuthorizationPolicy<Identity>: Sendable {
+    /// The identity type this policy evaluates.
+    associatedtype Identity: Sendable
+
+    /// Evaluate whether the given identity is authorized to proceed with the request.
+    ///
+    /// - Parameters:
+    ///   - identity: The authenticated identity resolved by the preceding authenticator.
+    ///   - request: The incoming HTTP request.
+    /// - Returns: `true` if the identity is authorized, `false` to produce a 403 response.
+    /// - Throws: Any error, which propagates up the middleware chain unchanged.
+    func isAuthorized(identity: Identity, request: Request) async throws -> Bool
+}
+
+/// An ``AuthorizationPolicy`` backed by a closure.
+///
+/// Use this as an escape hatch when a full policy type is unnecessary:
+///
+/// ```swift
+/// IsAuthorizedMiddleware(
+///     ClosureAuthorizationPolicy { user, request in
+///         user.id == request.uri.queryParameters.get("userId")
+///     }
+/// )
+/// ```
+public struct ClosureAuthorizationPolicy<Identity: Sendable>: AuthorizationPolicy {
+    @usableFromInline
+    let closure: @Sendable (Identity, Request) async throws -> Bool
+
+    /// Initialize with a closure.
+    /// - Parameter closure: Receives the authenticated identity and the incoming request.
+    ///   Return `true` to allow, `false` to deny.
+    public init(_ closure: @escaping @Sendable (Identity, Request) async throws -> Bool) {
+        self.closure = closure
+    }
+
+    @inlinable
+    public func isAuthorized(identity: Identity, request: Request) async throws -> Bool {
+        try await self.closure(identity, request)
+    }
+}

--- a/Sources/HummingbirdAuthorization/Combinators.swift
+++ b/Sources/HummingbirdAuthorization/Combinators.swift
@@ -1,0 +1,112 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// A policy that passes only when **all** of its child policies pass.
+///
+/// Evaluation short-circuits on the first failing policy, so policies are
+/// executed in declaration order.
+///
+/// ```swift
+/// // Require the user to be both an editor AND hold the publish permission
+/// AllOf(
+///     RolePolicy("editor"),
+///     PermissionPolicy("posts:publish")
+/// )
+/// ```
+public struct AllOf<Identity: Sendable>: AuthorizationPolicy {
+    @usableFromInline
+    let policies: [any AuthorizationPolicy<Identity>]
+
+    /// Initialize with a variadic list of policies.
+    public init(_ policies: any AuthorizationPolicy<Identity>...) {
+        self.policies = policies
+    }
+
+    /// Initialize with an array of policies.
+    public init(_ policies: [any AuthorizationPolicy<Identity>]) {
+        self.policies = policies
+    }
+
+    @inlinable
+    public func isAuthorized(identity: Identity, request: Request) async throws -> Bool {
+        for policy in self.policies {
+            guard try await policy.isAuthorized(identity: identity, request: request) else {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+/// A policy that passes when **any** of its child policies pass.
+///
+/// Evaluation short-circuits on the first passing policy, so policies are
+/// executed in declaration order.
+///
+/// ```swift
+/// // Allow admins or moderators through
+/// AnyOf(
+///     RolePolicy("admin"),
+///     RolePolicy("moderator")
+/// )
+/// ```
+public struct AnyOf<Identity: Sendable>: AuthorizationPolicy {
+    @usableFromInline
+    let policies: [any AuthorizationPolicy<Identity>]
+
+    /// Initialize with a variadic list of policies.
+    public init(_ policies: any AuthorizationPolicy<Identity>...) {
+        self.policies = policies
+    }
+
+    /// Initialize with an array of policies.
+    public init(_ policies: [any AuthorizationPolicy<Identity>]) {
+        self.policies = policies
+    }
+
+    @inlinable
+    public func isAuthorized(identity: Identity, request: Request) async throws -> Bool {
+        for policy in self.policies {
+            if try await policy.isAuthorized(identity: identity, request: request) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+/// A policy that inverts the result of another policy.
+///
+/// ```swift
+/// // Deny banned users
+/// Not(RolePolicy("banned"))
+///
+/// // Compose freely with other combinators
+/// AllOf(
+///     RolePolicy("user"),
+///     Not(RolePolicy("banned"))
+/// )
+/// ```
+public struct Not<P: AuthorizationPolicy>: AuthorizationPolicy {
+    public typealias Identity = P.Identity
+
+    @usableFromInline
+    let policy: P
+
+    /// Initialize with the policy whose result will be inverted.
+    public init(_ policy: P) {
+        self.policy = policy
+    }
+
+    @inlinable
+    public func isAuthorized(identity: P.Identity, request: Request) async throws -> Bool {
+        try await !self.policy.isAuthorized(identity: identity, request: request)
+    }
+}

--- a/Sources/HummingbirdAuthorization/Combinators.swift
+++ b/Sources/HummingbirdAuthorization/Combinators.swift
@@ -10,8 +10,8 @@ import Hummingbird
 
 /// A policy that passes only when **all** of its child policies pass.
 ///
-/// Evaluation short-circuits on the first failing policy, so policies are
-/// executed in declaration order.
+/// Evaluation short-circuits on the first failing policy so subsequent policies
+/// are not evaluated.
 ///
 /// ```swift
 /// // Require the user to be both an editor AND hold the publish permission
@@ -19,7 +19,14 @@ import Hummingbird
 ///     RolePolicy("editor"),
 ///     PermissionPolicy("posts:publish")
 /// )
+///
+/// // Store as an opaque type when a let binding is needed
+/// let policy: some AuthorizationPolicy<User> = AllOf(
+///     RolePolicy<User>("editor"),
+///     PermissionPolicy<User>("posts:publish")
+/// )
 /// ```
+///
 public struct AllOf<Identity: Sendable>: AuthorizationPolicy {
     @usableFromInline
     let policies: [any AuthorizationPolicy<Identity>]
@@ -47,8 +54,8 @@ public struct AllOf<Identity: Sendable>: AuthorizationPolicy {
 
 /// A policy that passes when **any** of its child policies pass.
 ///
-/// Evaluation short-circuits on the first passing policy, so policies are
-/// executed in declaration order.
+/// Evaluation short-circuits on the first passing policy so subsequent policies
+/// are not evaluated.
 ///
 /// ```swift
 /// // Allow admins or moderators through
@@ -57,6 +64,7 @@ public struct AllOf<Identity: Sendable>: AuthorizationPolicy {
 ///     RolePolicy("moderator")
 /// )
 /// ```
+///
 public struct AnyOf<Identity: Sendable>: AuthorizationPolicy {
     @usableFromInline
     let policies: [any AuthorizationPolicy<Identity>]
@@ -94,19 +102,19 @@ public struct AnyOf<Identity: Sendable>: AuthorizationPolicy {
 ///     Not(RolePolicy("banned"))
 /// )
 /// ```
-public struct Not<P: AuthorizationPolicy>: AuthorizationPolicy {
-    public typealias Identity = P.Identity
+public struct Not<Policy: AuthorizationPolicy>: AuthorizationPolicy {
+    public typealias Identity = Policy.Identity
 
     @usableFromInline
-    let policy: P
+    let policy: Policy
 
     /// Initialize with the policy whose result will be inverted.
-    public init(_ policy: P) {
+    public init(_ policy: Policy) {
         self.policy = policy
     }
 
     @inlinable
-    public func isAuthorized(identity: P.Identity, request: Request) async throws -> Bool {
+    public func isAuthorized(identity: Policy.Identity, request: Request) async throws -> Bool {
         try await !self.policy.isAuthorized(identity: identity, request: request)
     }
 }

--- a/Sources/HummingbirdAuthorization/IsAuthorizedMiddleware.swift
+++ b/Sources/HummingbirdAuthorization/IsAuthorizedMiddleware.swift
@@ -1,0 +1,68 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+import HummingbirdAuth
+
+/// Middleware that enforces an ``AuthorizationPolicy`` on every request it handles.
+///
+/// Place this middleware *after* an authenticator and ``IsAuthenticatedMiddleware``
+/// in the middleware chain:
+///
+/// ```swift
+/// router.group()
+///     .add(middleware: MyAuthenticator())
+///     .add(middleware: IsAuthenticatedMiddleware())
+///     .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+///     .get("admin/dashboard") { _, _ in ... }
+/// ```
+///
+/// Policies compose freely via ``AllOf``, ``AnyOf``, and ``Not``:
+///
+/// ```swift
+/// IsAuthorizedMiddleware(
+///     AnyOf(
+///         RolePolicy("admin"),
+///         AllOf(RolePolicy("editor"), PermissionPolicy("posts:publish"))
+///     )
+/// )
+/// ```
+///
+/// - Throws ``HTTPError(.unauthorized)`` (401) if the request context carries no identity.
+/// - Throws ``HTTPError(.forbidden)`` (403) if the policy denies the identity.
+public struct IsAuthorizedMiddleware<
+    Policy: AuthorizationPolicy,
+    Context: AuthRequestContext
+>: RouterMiddleware where Context.Identity == Policy.Identity {
+
+    @usableFromInline
+    let policy: Policy
+
+    /// Initialize with an authorization policy.
+    /// - Parameters:
+    ///   - policy: The policy evaluated for every request in this middleware group.
+    ///   - context: The request context type (used for type inference only).
+    public init(_ policy: Policy, context: Context.Type = Context.self) {
+        self.policy = policy
+    }
+
+    @inlinable
+    public func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        guard let identity = context.identity else {
+            throw HTTPError(.unauthorized)
+        }
+        guard try await self.policy.isAuthorized(identity: identity, request: request) else {
+            throw HTTPError(.forbidden)
+        }
+        return try await next(request, context)
+    }
+}

--- a/Sources/HummingbirdAuthorization/PermissionPolicy.swift
+++ b/Sources/HummingbirdAuthorization/PermissionPolicy.swift
@@ -8,7 +8,7 @@
 
 import Hummingbird
 
-/// A type whose instances carry a set of fine-grained permissions.
+/// A type whose instances carry a collection of fine-grained permissions.
 ///
 /// Conform your identity type to `PermissionProviding` to enable ``PermissionPolicy``:
 ///
@@ -18,14 +18,13 @@ import Hummingbird
 /// }
 /// ```
 ///
-/// The `Permission` associated type can be any `Hashable & Sendable` value — commonly
-/// a scoped `String` (e.g. `"posts:write"`) or a custom enum:
+/// The `Permissions` associated type can be any `SetAlgebra` conformance — commonly
+/// `Set<Permission>`, but a compact array-backed type works equally well for identities
+/// that hold only a handful of permissions:
 ///
 /// ```swift
 /// enum Permission: String, Hashable, Sendable {
-///     case postsRead   = "posts:read"
-///     case postsWrite  = "posts:write"
-///     case usersDelete = "users:delete"
+///     case postsRead = "posts:read", postsWrite = "posts:write"
 /// }
 ///
 /// struct User: PermissionProviding {
@@ -36,12 +35,22 @@ import Hummingbird
 /// An identity type can conform to both ``RoleProviding`` and `PermissionProviding`,
 /// allowing ``RolePolicy`` and ``PermissionPolicy`` to be freely mixed via
 /// ``AllOf`` and ``AnyOf``.
+///
+/// - Note: `PermissionProviding` and ``RoleProviding`` are structurally identical
+///   protocols. They are kept separate so that a type may conform to one without
+///   the other (permissions without roles, or vice-versa), and so that the type
+///   system can enforce that ``PermissionPolicy`` only applies to permission-aware
+///   identities while ``RolePolicy`` only applies to role-aware identities.
 public protocol PermissionProviding: Sendable {
-    /// The permission type. Commonly `String` or a dedicated `enum`.
-    associatedtype Permission: Hashable & Sendable
+    /// The collection type used to store permissions.
+    ///
+    /// Must conform to `SetAlgebra` so that ``PermissionPolicy`` can call `contains`.
+    /// The element type (`Permissions.Element`) is the permission type — commonly
+    /// a scoped `String` (e.g. `"posts:write"`) or a dedicated `enum`.
+    associatedtype Permissions: SetAlgebra & Sendable where Permissions.Element: Equatable & Sendable
 
-    /// The set of permissions this identity holds.
-    var permissions: Set<Permission> { get }
+    /// The collection of permissions this identity holds.
+    var permissions: Permissions { get }
 }
 
 /// A policy that requires the identity to hold a specific permission.
@@ -65,10 +74,10 @@ public protocol PermissionProviding: Sendable {
 /// ```
 public struct PermissionPolicy<Identity: PermissionProviding>: AuthorizationPolicy {
     @usableFromInline
-    let permission: Identity.Permission
+    let permission: Identity.Permissions.Element
 
     /// Initialize with the permission to require.
-    public init(_ permission: Identity.Permission) {
+    public init(_ permission: Identity.Permissions.Element) {
         self.permission = permission
     }
 

--- a/Sources/HummingbirdAuthorization/PermissionPolicy.swift
+++ b/Sources/HummingbirdAuthorization/PermissionPolicy.swift
@@ -1,0 +1,79 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// A type whose instances carry a set of fine-grained permissions.
+///
+/// Conform your identity type to `PermissionProviding` to enable ``PermissionPolicy``:
+///
+/// ```swift
+/// struct User: PermissionProviding {
+///     var permissions: Set<String>
+/// }
+/// ```
+///
+/// The `Permission` associated type can be any `Hashable & Sendable` value — commonly
+/// a scoped `String` (e.g. `"posts:write"`) or a custom enum:
+///
+/// ```swift
+/// enum Permission: String, Hashable, Sendable {
+///     case postsRead   = "posts:read"
+///     case postsWrite  = "posts:write"
+///     case usersDelete = "users:delete"
+/// }
+///
+/// struct User: PermissionProviding {
+///     var permissions: Set<Permission>
+/// }
+/// ```
+///
+/// An identity type can conform to both ``RoleProviding`` and `PermissionProviding`,
+/// allowing ``RolePolicy`` and ``PermissionPolicy`` to be freely mixed via
+/// ``AllOf`` and ``AnyOf``.
+public protocol PermissionProviding: Sendable {
+    /// The permission type. Commonly `String` or a dedicated `enum`.
+    associatedtype Permission: Hashable & Sendable
+
+    /// The set of permissions this identity holds.
+    var permissions: Set<Permission> { get }
+}
+
+/// A policy that requires the identity to hold a specific permission.
+///
+/// Combine with ``AnyOf``, ``AllOf``, and ``Not`` for richer rules,
+/// and mix freely with ``RolePolicy`` when the identity conforms to both
+/// ``RoleProviding`` and ``PermissionProviding``:
+///
+/// ```swift
+/// // Require a single permission
+/// PermissionPolicy("posts:publish")
+///
+/// // Require any one of several permissions
+/// AnyOf(PermissionPolicy("posts:write"), PermissionPolicy("posts:publish"))
+///
+/// // Combine role and permission checks on the same identity
+/// AllOf(
+///     RolePolicy("editor"),
+///     PermissionPolicy("posts:publish")
+/// )
+/// ```
+public struct PermissionPolicy<Identity: PermissionProviding>: AuthorizationPolicy {
+    @usableFromInline
+    let permission: Identity.Permission
+
+    /// Initialize with the permission to require.
+    public init(_ permission: Identity.Permission) {
+        self.permission = permission
+    }
+
+    @inlinable
+    public func isAuthorized(identity: Identity, request: Request) async throws -> Bool {
+        identity.permissions.contains(self.permission)
+    }
+}

--- a/Sources/HummingbirdAuthorization/PermissionPolicy.swift
+++ b/Sources/HummingbirdAuthorization/PermissionPolicy.swift
@@ -47,7 +47,7 @@ public protocol PermissionProviding: Sendable {
     /// Must conform to `SetAlgebra` so that ``PermissionPolicy`` can call `contains`.
     /// The element type (`Permissions.Element`) is the permission type — commonly
     /// a scoped `String` (e.g. `"posts:write"`) or a dedicated `enum`.
-    associatedtype Permissions: SetAlgebra & Sendable where Permissions.Element: Equatable & Sendable
+    associatedtype Permissions: SetAlgebra & Sendable where Permissions.Element: Sendable
 
     /// The collection of permissions this identity holds.
     var permissions: Permissions { get }

--- a/Sources/HummingbirdAuthorization/RolePolicy.swift
+++ b/Sources/HummingbirdAuthorization/RolePolicy.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// A type whose instances carry a set of roles.
+///
+/// Conform your identity type to `RoleProviding` to enable ``RolePolicy``:
+///
+/// ```swift
+/// struct User: RoleProviding {
+///     var roles: Set<String>
+/// }
+/// ```
+///
+/// The `Role` associated type can be any `Hashable & Sendable` value — commonly
+/// a `String` or a custom enum for compile-time exhaustiveness:
+///
+/// ```swift
+/// enum Role: String, Hashable, Sendable {
+///     case admin, editor, moderator, user, banned
+/// }
+///
+/// struct User: RoleProviding {
+///     var roles: Set<Role>
+/// }
+/// ```
+public protocol RoleProviding: Sendable {
+    /// The role type. Commonly `String` or a dedicated `enum`.
+    associatedtype Role: Hashable & Sendable
+
+    /// The set of roles this identity holds.
+    var roles: Set<Role> { get }
+}
+
+/// A policy that requires the identity to hold a specific role.
+///
+/// Combine with ``AnyOf``, ``AllOf``, and ``Not`` for richer rules:
+///
+/// ```swift
+/// // Pass if the user is an admin
+/// RolePolicy("admin")
+///
+/// // Pass if the user is an admin OR a moderator
+/// AnyOf(RolePolicy("admin"), RolePolicy("moderator"))
+///
+/// // Pass if the user is both verified AND an editor
+/// AllOf(RolePolicy("editor"), RolePolicy("verified"))
+///
+/// // Pass if the user is NOT banned
+/// Not(RolePolicy("banned"))
+/// ```
+public struct RolePolicy<Identity: RoleProviding>: AuthorizationPolicy {
+    @usableFromInline
+    let role: Identity.Role
+
+    /// Initialize with the role to require.
+    public init(_ role: Identity.Role) {
+        self.role = role
+    }
+
+    @inlinable
+    public func isAuthorized(identity: Identity, request: Request) async throws -> Bool {
+        identity.roles.contains(self.role)
+    }
+}

--- a/Sources/HummingbirdAuthorization/RolePolicy.swift
+++ b/Sources/HummingbirdAuthorization/RolePolicy.swift
@@ -42,7 +42,7 @@ public protocol RoleProviding: Sendable {
     /// Must conform to `SetAlgebra` so that ``RolePolicy`` can call `contains`.
     /// The element type (`Roles.Element`) is the role type — commonly `String`
     /// or a dedicated `enum`.
-    associatedtype Roles: SetAlgebra & Sendable where Roles.Element: Equatable & Sendable
+    associatedtype Roles: SetAlgebra & Sendable where Roles.Element: Sendable
 
     /// The collection of roles this identity holds.
     var roles: Roles { get }

--- a/Sources/HummingbirdAuthorization/RolePolicy.swift
+++ b/Sources/HummingbirdAuthorization/RolePolicy.swift
@@ -8,7 +8,7 @@
 
 import Hummingbird
 
-/// A type whose instances carry a set of roles.
+/// A type whose instances carry a collection of roles.
 ///
 /// Conform your identity type to `RoleProviding` to enable ``RolePolicy``:
 ///
@@ -18,24 +18,34 @@ import Hummingbird
 /// }
 /// ```
 ///
-/// The `Role` associated type can be any `Hashable & Sendable` value — commonly
-/// a `String` or a custom enum for compile-time exhaustiveness:
+/// The `Roles` associated type can be any `SetAlgebra` conformance — commonly
+/// `Set<Role>`, but a compact array-backed type works equally well for identities
+/// that hold only a handful of roles:
 ///
 /// ```swift
-/// enum Role: String, Hashable, Sendable {
-///     case admin, editor, moderator, user, banned
-/// }
+/// enum Role: String, Hashable, Sendable { case admin, editor, moderator }
 ///
 /// struct User: RoleProviding {
-///     var roles: Set<Role>
+///     var roles: Set<Role>         // Set for general use
+///     // or: var roles: MyArraySet<Role>  // linear scan, faster for N < ~8
 /// }
 /// ```
+///
+/// - Note: `RoleProviding` and ``PermissionProviding`` are structurally identical
+///   protocols. They are kept separate so that a type may conform to one without
+///   the other (roles without permissions, or vice-versa), and so that the type
+///   system can enforce that ``RolePolicy`` only applies to role-aware identities
+///   while ``PermissionPolicy`` only applies to permission-aware identities.
 public protocol RoleProviding: Sendable {
-    /// The role type. Commonly `String` or a dedicated `enum`.
-    associatedtype Role: Hashable & Sendable
+    /// The collection type used to store roles.
+    ///
+    /// Must conform to `SetAlgebra` so that ``RolePolicy`` can call `contains`.
+    /// The element type (`Roles.Element`) is the role type — commonly `String`
+    /// or a dedicated `enum`.
+    associatedtype Roles: SetAlgebra & Sendable where Roles.Element: Equatable & Sendable
 
-    /// The set of roles this identity holds.
-    var roles: Set<Role> { get }
+    /// The collection of roles this identity holds.
+    var roles: Roles { get }
 }
 
 /// A policy that requires the identity to hold a specific role.
@@ -57,10 +67,10 @@ public protocol RoleProviding: Sendable {
 /// ```
 public struct RolePolicy<Identity: RoleProviding>: AuthorizationPolicy {
     @usableFromInline
-    let role: Identity.Role
+    let role: Identity.Roles.Element
 
     /// Initialize with the role to require.
-    public init(_ role: Identity.Role) {
+    public init(_ role: Identity.Roles.Element) {
         self.role = role
     }
 

--- a/Tests/HummingbirdAuthTests/AuthorizationTests.swift
+++ b/Tests/HummingbirdAuthTests/AuthorizationTests.swift
@@ -1,0 +1,437 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+import HummingbirdAuth
+import HummingbirdAuthorization
+import HummingbirdTesting
+import Testing
+
+// MARK: - Test identity
+
+/// Identity used across all authorization tests.
+/// Conforms to both ``RoleProviding`` and ``PermissionProviding`` so that
+/// ``RolePolicy``, ``PermissionPolicy``, and their combinations can all be
+/// exercised with a single type.
+private struct User: Sendable, RoleProviding, PermissionProviding {
+    let name: String
+    var roles: Set<String>
+    var permissions: Set<String>
+
+    init(name: String, roles: Set<String> = [], permissions: Set<String> = []) {
+        self.name = name
+        self.roles = roles
+        self.permissions = permissions
+    }
+}
+
+// MARK: - Tests
+
+struct AuthorizationTests {
+
+    // MARK: IsAuthorizedMiddleware — HTTP status codes
+
+    @Test func testIsAuthorizedMiddlewareAllows() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            // Authenticator always succeeds — sets context.identity
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "admin", roles: ["admin"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+        }
+    }
+
+    @Test func testIsAuthorizedMiddlewareForbids() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "guest", roles: ["user"])  // authenticated but wrong role
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    @Test func testIsAuthorizedMiddlewareRequiresAuthentication() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            // No authenticator — context.identity is nil
+            .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .unauthorized)
+            }
+        }
+    }
+
+    // MARK: ClosureAuthorizationPolicy
+
+    @Test func testClosureAuthorizationPolicy() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "alice")
+                }
+            )
+            .add(
+                middleware: IsAuthorizedMiddleware(
+                    ClosureAuthorizationPolicy { user, request in
+                        // Allow only requests whose "user" query param matches the identity name
+                        user.name == request.uri.queryParameters.get("user")
+                    }
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource?user=alice", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/resource?user=bob", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: AllOf combinator
+
+    @Test func testAllOfPassesWhenAllPoliciesPass() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "editor", roles: ["editor", "verified"])
+                }
+            )
+            .add(
+                middleware: IsAuthorizedMiddleware(
+                    AllOf(RolePolicy("editor"), RolePolicy("verified"))
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+        }
+    }
+
+    @Test func testAllOfFailsWhenAnyPolicyFails() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "editor", roles: ["editor"])  // missing "verified"
+                }
+            )
+            .add(
+                middleware: IsAuthorizedMiddleware(
+                    AllOf(RolePolicy("editor"), RolePolicy("verified"))
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: AnyOf combinator
+
+    @Test func testAnyOfPassesWhenOnePolicyPasses() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "mod", roles: ["moderator"])  // no "admin" but has "moderator"
+                }
+            )
+            .add(
+                middleware: IsAuthorizedMiddleware(
+                    AnyOf(RolePolicy("admin"), RolePolicy("moderator"))
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+        }
+    }
+
+    @Test func testAnyOfFailsWhenNoPolicyPasses() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "guest", roles: ["user"])  // neither admin nor moderator
+                }
+            )
+            .add(
+                middleware: IsAuthorizedMiddleware(
+                    AnyOf(RolePolicy("admin"), RolePolicy("moderator"))
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: Not combinator
+
+    @Test func testNotInverts() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        // Route 1: user without "banned" role → allowed
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "alice", roles: ["user"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(Not(RolePolicy("banned"))))
+            .get("allowed") { _, _ -> HTTPResponse.Status in .ok }
+
+        // Route 2: banned user → forbidden
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "mallory", roles: ["banned"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(Not(RolePolicy("banned"))))
+            .get("denied") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/allowed", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/denied", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: RolePolicy
+
+    @Test func testRolePolicy() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "admin", roles: ["admin"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+            .get("admin") { _, _ -> HTTPResponse.Status in .ok }
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "guest", roles: ["user"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(RolePolicy("admin")))
+            .get("no-access") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/admin", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/no-access", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: PermissionPolicy
+
+    @Test func testPermissionPolicy() async throws {
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "publisher", permissions: ["posts:publish"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(PermissionPolicy("posts:publish")))
+            .get("publish") { _, _ -> HTTPResponse.Status in .ok }
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "reader", permissions: ["posts:read"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(PermissionPolicy("posts:publish")))
+            .get("no-publish") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/publish", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/no-publish", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: Role + Permission composition
+
+    @Test func testRoleAndPermissionComposition() async throws {
+        // Requires "editor" role AND "posts:publish" permission
+        let policy = AllOf<User>(
+            RolePolicy("editor"),
+            PermissionPolicy("posts:publish")
+        )
+
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        // Has role + permission → allowed
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "alice", roles: ["editor"], permissions: ["posts:publish"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("can-publish") { _, _ -> HTTPResponse.Status in .ok }
+
+        // Has role but not permission → forbidden
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "bob", roles: ["editor"], permissions: ["posts:read"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("no-permission") { _, _ -> HTTPResponse.Status in .ok }
+
+        // Has permission but not role → forbidden
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "charlie", roles: ["user"], permissions: ["posts:publish"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("no-role") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/can-publish", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/no-permission", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+            try await client.execute(uri: "/no-role", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+
+    // MARK: Deep composition
+
+    @Test func testDeepComposition() async throws {
+        // (admin OR (editor AND posts:publish)) AND NOT banned
+        let policy = AllOf<User>(
+            AnyOf<User>(
+                RolePolicy("admin"),
+                AllOf<User>(
+                    RolePolicy("editor"),
+                    PermissionPolicy("posts:publish")
+                )
+            ),
+            Not(RolePolicy("banned"))
+        )
+
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "admin", roles: ["admin"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("admin") { _, _ -> HTTPResponse.Status in .ok }
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    User(name: "editor", roles: ["editor"], permissions: ["posts:publish"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("editor") { _, _ -> HTTPResponse.Status in .ok }
+
+        router.group()
+            .add(
+                middleware: ClosureAuthenticator { _, _ in
+                    // admin but banned
+                    User(name: "banned-admin", roles: ["admin", "banned"])
+                }
+            )
+            .add(middleware: IsAuthorizedMiddleware(policy))
+            .get("banned") { _, _ -> HTTPResponse.Status in .ok }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/admin", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/editor", method: .get) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(uri: "/banned", method: .get) { response in
+                #expect(response.status == .forbidden)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding Authz support.

The current implementation supports basic role and permissions. ABAC can be handled at the application level using the composite identity pattern.

Moreover, this implementation is plug and play and therefore both OPA and CASBIN can be implemented at the application level since resources can be fetched asynchronously. I am experimenting with a higher level package which builds on top of hummingbird-auth.

ABAC example
```swift
// 1. A rich composite "subject" that carries both user and resource
struct DocumentRequest: Sendable {
    let user: User
    let document: Document   // resolved once, available to all policies
}

// 2. A middleware that resolves the resource and packs it into the context
struct DocumentRequestMiddleware: AuthenticatorMiddleware {
    typealias Identity = DocumentRequest
    let db: some DocumentRepository

    func authenticate(request: Request, context: some AuthRequestContext<DocumentRequest>)
    async throws -> DocumentRequest? {
        // Requires a prior authenticator to have set the raw user
        guard let user = context.identity?.user,
              let docID = request.uri.queryParameters.get("id").flatMap(UUID.init),
              let doc = try await db.findDocument(docID)
        else { return nil }
        return DocumentRequest(user: user, document: doc)
    }
}

// 3. Policies now work purely from memory — zero extra DB calls
struct IsDocumentOwner: AuthorizationPolicy {
    func isAuthorized(identity: DocumentRequest, request: Request) async throws -> Bool {
        identity.document.authorID == identity.user.id
    }
}

struct DocumentIsPublished: AuthorizationPolicy {
    func isAuthorized(identity: DocumentRequest, request: Request) async throws -> Bool {
        identity.document.status == .published
    }
}

// 4. The full chain — reads cleanly, resolves once
router.group()
    .add(middleware: UserAuthenticator())           // sets User identity
    .add(middleware: DocumentRequestMiddleware())   // upgrades to DocumentRequest identity
    .add(middleware: IsAuthorizedMiddleware(
        AnyOf(
            RolePolicy(\.user.roles, "admin"),
            AllOf(IsDocumentOwner(), DocumentIsPublished())
        )
    ))
    .put("documents") { ... }
```