### PR TITLE
Add AuthorizationScope and QueryFilter for collection-level authorization

### DIFF
--- a/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
+++ b/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
@@ -31,7 +31,7 @@ import Hummingbird
 /// }
 /// ```
 ///
-/// Apply with ``Sequence/filter(scope:identity:request:)`` in a collection handler:
+/// Apply with `filter(scope:identity:request:)` in a collection handler:
 ///
 /// ```swift
 /// func list(_ request: Request, context: Context) async throws -> [DocumentResponse] {

--- a/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
+++ b/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
@@ -8,13 +8,13 @@
 
 import Hummingbird
 
-/// Answers *"given this identity, which resources can they see?"*
+/// Determines which resources an authenticated identity may see.
 ///
-/// The complement to ``AuthorizationPolicy``, which answers the point query
-/// *"can this identity see this specific resource?"*
+/// Works in two phases with ``QueryFilter``:
 ///
-/// All async work belongs in ``filter(for:request:)``. The returned
-/// ``QueryFilter`` carries the resolved data and applies it per resource.
+/// 1. ``filter(for:request:)`` runs once — resolves allowed IDs, fetches policy
+///    decisions, reads from cache — and returns a ``QueryFilter``.
+/// 2. ``QueryFilter/matches(_:)`` runs per element using data already in memory.
 ///
 /// ```swift
 /// struct DocumentScope: AuthorizationScope {
@@ -22,22 +22,61 @@ import Hummingbird
 ///     typealias Filter = ClosureQueryFilter<Document>
 ///
 ///     func filter(for identity: User, request: Request) async throws -> Filter {
-///         let ids = try await store.list(subject: identity.id)
-///         let allowed = Set(ids)
+///         // Async work here — called once regardless of collection size
+///         let allowed = try await store.list(subject: identity.id, relation: .viewer)
 ///         return ClosureQueryFilter { document in
 ///             document.id.map { allowed.contains($0) } ?? false
 ///         }
 ///     }
 /// }
 /// ```
+///
+/// Apply with ``Sequence/filter(scope:identity:request:)`` in a collection handler:
+///
+/// ```swift
+/// func list(_ request: Request, context: Context) async throws -> [DocumentResponse] {
+///     let identity = try context.requireIdentity()
+///     return try await Document.query(on: db).all()
+///         .filter(scope: documentScope, identity: identity, request: request)
+///         .map { DocumentResponse(from: $0) }
+/// }
+/// ```
 public protocol AuthorizationScope<Identity>: Sendable {
     /// The identity type this scope evaluates.
     associatedtype Identity: Sendable
 
-    /// The filter type returned. Carries resolved constraint data and applies it
-    /// to individual resources via ``QueryFilter/matches(_:)``.
+    /// The filter type produced by this scope.
     associatedtype Filter: QueryFilter
 
-    /// Compute the filter for this identity. Called once per collection request.
+    /// Resolve the filter for this identity.
+    /// Called once per collection request; the returned ``QueryFilter`` is
+    /// applied to each element in the collection.
     func filter(for identity: Identity, request: Request) async throws -> Filter
+}
+
+// MARK: - Sequence integration
+
+extension Sequence {
+    /// Returns elements the given identity may see according to `scope`.
+    ///
+    /// ```swift
+    /// return try await Document.query(on: db).all()
+    ///     .filter(scope: documentScope, identity: identity, request: request)
+    ///     .map { DocumentResponse(from: $0) }
+    /// ```
+    public func filter<Scope: AuthorizationScope>(
+        scope: Scope,
+        identity: Scope.Identity,
+        request: Request
+    ) async throws -> [Element] where Scope.Filter.Resource == Element {
+        let queryFilter = try await scope.filter(for: identity, request: request)
+        var result: [Element] = []
+        result.reserveCapacity(underestimatedCount)
+        for element in self {
+            if try await queryFilter.matches(element) {
+                result.append(element)
+            }
+        }
+        return result
+    }
 }

--- a/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
+++ b/Sources/HummingbirdAuth/Authorization/AuthorizationScope.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// Answers *"given this identity, which resources can they see?"*
+///
+/// The complement to ``AuthorizationPolicy``, which answers the point query
+/// *"can this identity see this specific resource?"*
+///
+/// All async work belongs in ``filter(for:request:)``. The returned
+/// ``QueryFilter`` carries the resolved data and applies it per resource.
+///
+/// ```swift
+/// struct DocumentScope: AuthorizationScope {
+///     typealias Identity = User
+///     typealias Filter = ClosureQueryFilter<Document>
+///
+///     func filter(for identity: User, request: Request) async throws -> Filter {
+///         let ids = try await store.list(subject: identity.id)
+///         let allowed = Set(ids)
+///         return ClosureQueryFilter { document in
+///             document.id.map { allowed.contains($0) } ?? false
+///         }
+///     }
+/// }
+/// ```
+public protocol AuthorizationScope<Identity>: Sendable {
+    /// The identity type this scope evaluates.
+    associatedtype Identity: Sendable
+
+    /// The filter type returned. Carries resolved constraint data and applies it
+    /// to individual resources via ``QueryFilter/matches(_:)``.
+    associatedtype Filter: QueryFilter
+
+    /// Compute the filter for this identity. Called once per collection request.
+    func filter(for identity: Identity, request: Request) async throws -> Filter
+}

--- a/Sources/HummingbirdAuth/Authorization/QueryFilter.swift
+++ b/Sources/HummingbirdAuth/Authorization/QueryFilter.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Hummingbird
+
+/// A resolved filter returned by ``AuthorizationScope/filter(for:request:)``.
+///
+/// The concrete type carries whatever data was resolved during the async
+/// computation — a set of allowed IDs, a predicate, a list of constraints —
+/// and applies it synchronously per resource via ``matches(_:)``.
+public protocol QueryFilter<Resource>: Sendable {
+    /// The resource type this filter operates on.
+    associatedtype Resource: Sendable
+
+    /// Return `true` if this resource should be included in the result.
+    func matches(_ resource: Resource) async throws -> Bool
+}
+
+/// A ``QueryFilter`` backed by a closure.
+public struct ClosureQueryFilter<Resource: Sendable>: QueryFilter {
+    @usableFromInline
+    let closure: @Sendable (Resource) async throws -> Bool
+
+    /// - Parameter closure: Return `true` to include the resource, `false` to exclude it.
+    public init(_ closure: @escaping @Sendable (Resource) async throws -> Bool) {
+        self.closure = closure
+    }
+
+    @inlinable
+    public func matches(_ resource: Resource) async throws -> Bool {
+        try await closure(resource)
+    }
+}

--- a/Sources/HummingbirdAuth/Authorization/QueryFilter.swift
+++ b/Sources/HummingbirdAuth/Authorization/QueryFilter.swift
@@ -8,11 +8,17 @@
 
 import Hummingbird
 
-/// A resolved filter returned by ``AuthorizationScope/filter(for:request:)``.
+/// The evaluation half of the two-phase collection authorization pattern.
 ///
-/// The concrete type carries whatever data was resolved during the async
-/// computation — a set of allowed IDs, a predicate, a list of constraints —
-/// and applies it synchronously per resource via ``matches(_:)``.
+/// ``AuthorizationScope/filter(for:request:)`` is the *resolution* phase — it runs
+/// once per request and does the async work (store queries, policy engine calls).
+/// `QueryFilter` is the *evaluation* phase — ``matches(_:)`` is called once per
+/// resource using data already in memory, with no further I/O.
+///
+/// ```
+/// AuthorizationScope.filter(for:request:)  →  async, once    (resolve allowed IDs)
+/// QueryFilter.matches(_:)                  →  sync,  N times  (check each resource)
+/// ```
 public protocol QueryFilter<Resource>: Sendable {
     /// The resource type this filter operates on.
     associatedtype Resource: Sendable

--- a/Tests/HummingbirdAuthTests/ScopeTests.swift
+++ b/Tests/HummingbirdAuthTests/ScopeTests.swift
@@ -1,0 +1,190 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Hummingbird
+import HummingbirdAuth
+import HummingbirdTesting
+import Testing
+
+// MARK: - Shared test identity
+
+private struct User: Sendable, RoleProviding, PermissionProviding {
+    let name: String
+    var roles: Set<String> = []
+    var permissions: Set<String> = []
+}
+
+// MARK: - Shared scope helper
+
+/// Scope backed by an explicit allow-list per user name.
+/// Stands in for any actual backend (OPA list, Casbin enforcement, ReBAC store query).
+private struct AllowListScope: AuthorizationScope {
+    typealias Identity = User
+    typealias Filter = ClosureQueryFilter<String>
+
+    let allowed: [String: Set<String>]
+
+    func filter(for identity: User, request: Request) async throws -> ClosureQueryFilter<String> {
+        let ids = allowed[identity.name] ?? []
+        return ClosureQueryFilter { ids.contains($0) }
+    }
+}
+
+// MARK: - Tests
+
+struct ScopeTests {
+
+    // MARK: Optional policy semantics
+
+    @Test func testAllOfBuildOptionalAbsentBranchPasses() async throws {
+        // In allOf: an absent `if` branch is vacuously true (no constraint added)
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "editor", roles: ["editor"]) })
+            .add(
+                middleware: AuthorizationPolicyMiddleware(
+                    allOf {
+                        RolePolicy("editor")
+                        if false { PermissionPolicy("extra") }  // absent — passes
+                    }
+                )
+            )
+            .get("resource") { _, _ -> HTTPResponse.Status in .ok }
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/resource", method: .get) { response in
+                #expect(response.status == .ok)  // absent allOf branch is a no-op
+            }
+        }
+    }
+
+    @Test func testAnyOfBuildOptionalAbsentBranchFails() async throws {
+        // In anyOf: an absent `if` branch contributes nothing — does NOT force a pass
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "editor", roles: ["editor"]) })
+            .add(
+                middleware: AuthorizationPolicyMiddleware(
+                    anyOf {
+                        if false { RolePolicy("admin") }  // absent — fails, not passes
+                        RolePolicy("editor")  // this one actually passes
+                    }
+                )
+            )
+            .get("passes") { _, _ -> HTTPResponse.Status in .ok }
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "editor", roles: ["editor"]) })
+            .add(
+                middleware: AuthorizationPolicyMiddleware(
+                    anyOf {
+                        if false { RolePolicy("admin") }  // absent — must NOT force true
+                    }
+                )
+            )
+            .get("fails") { _, _ -> HTTPResponse.Status in .ok }
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/passes", method: .get) { response in
+                #expect(response.status == .ok)  // editor branch passed
+            }
+            try await client.execute(uri: "/fails", method: .get) { response in
+                #expect(response.status == .forbidden)  // no branch passed
+            }
+        }
+    }
+
+    // MARK: QueryFilter
+
+    @Test func testClosureQueryFilterMatchesPredicate() async throws {
+        let filter = ClosureQueryFilter<String> { s in s.hasPrefix("pub-") }
+        #expect(try await filter.matches("pub-doc") == true)
+        #expect(try await filter.matches("pub-report") == true)
+        #expect(try await filter.matches("private-doc") == false)
+        #expect(try await filter.matches("") == false)
+    }
+
+    @Test func testClosureQueryFilterPropagatesThrows() async throws {
+        struct FilterError: Error {}
+        let filter = ClosureQueryFilter<String> { _ in throw FilterError() }
+        await #expect(throws: FilterError.self) {
+            _ = try await filter.matches("any")
+        }
+    }
+
+    // MARK: AuthorizationScope
+
+    @Test func testScopeFiltersCollectionPerIdentity() async throws {
+        let scope = AllowListScope(allowed: [
+            "editor": ["doc-1", "doc-2"],
+            "admin": ["doc-1", "doc-2", "doc-3"],
+        ])
+        let allItems = ["doc-1", "doc-2", "doc-3", "doc-other"]
+
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "editor") })
+            .get("editor/items") { request, context -> [String] in
+                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
+                let filter = try await scope.filter(for: identity, request: request)
+                var result: [String] = []
+                for item in allItems { if try await filter.matches(item) { result.append(item) } }
+                return result.sorted()
+            }
+
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "admin") })
+            .get("admin/items") { request, context -> [String] in
+                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
+                let filter = try await scope.filter(for: identity, request: request)
+                var result: [String] = []
+                for item in allItems { if try await filter.matches(item) { result.append(item) } }
+                return result.sorted()
+            }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/editor/items", method: .get) { response in
+                #expect(response.status == .ok)
+                let items = try JSONDecoder().decode([String].self, from: response.body)
+                #expect(items == ["doc-1", "doc-2"])
+            }
+            try await client.execute(uri: "/admin/items", method: .get) { response in
+                #expect(response.status == .ok)
+                let items = try JSONDecoder().decode([String].self, from: response.body)
+                #expect(items == ["doc-1", "doc-2", "doc-3"])
+            }
+        }
+    }
+
+    @Test func testScopeReturnsEmptyForUnknownIdentity() async throws {
+        let scope = AllowListScope(allowed: [:])
+        let allItems = ["doc-1", "doc-2"]
+
+        let router = Router(context: BasicAuthRequestContext<User>.self)
+        router.group()
+            .add(middleware: ClosureAuthenticator { _, _ in User(name: "stranger") })
+            .get("items") { request, context -> [String] in
+                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
+                let filter = try await scope.filter(for: identity, request: request)
+                var result: [String] = []
+                for item in allItems { if try await filter.matches(item) { result.append(item) } }
+                return result
+            }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/items", method: .get) { response in
+                #expect(response.status == .ok)
+                let items = try JSONDecoder().decode([String].self, from: response.body)
+                #expect(items.isEmpty)
+            }
+        }
+    }
+}

--- a/Tests/HummingbirdAuthTests/ScopeTests.swift
+++ b/Tests/HummingbirdAuthTests/ScopeTests.swift
@@ -131,21 +131,22 @@ struct ScopeTests {
         router.group()
             .add(middleware: ClosureAuthenticator { _, _ in User(name: "editor") })
             .get("editor/items") { request, context -> [String] in
-                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
-                let filter = try await scope.filter(for: identity, request: request)
-                var result: [String] = []
-                for item in allItems { if try await filter.matches(item) { result.append(item) } }
-                return result.sorted()
+                let identity = try context.requireIdentity()
+                // Sequence.filter(scope:identity:request:) — the primary integration point
+                return
+                    try await allItems
+                    .filter(scope: scope, identity: identity, request: request)
+                    .sorted()
             }
 
         router.group()
             .add(middleware: ClosureAuthenticator { _, _ in User(name: "admin") })
             .get("admin/items") { request, context -> [String] in
-                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
-                let filter = try await scope.filter(for: identity, request: request)
-                var result: [String] = []
-                for item in allItems { if try await filter.matches(item) { result.append(item) } }
-                return result.sorted()
+                let identity = try context.requireIdentity()
+                return
+                    try await allItems
+                    .filter(scope: scope, identity: identity, request: request)
+                    .sorted()
             }
 
         let app = Application(responder: router.buildResponder())
@@ -171,11 +172,10 @@ struct ScopeTests {
         router.group()
             .add(middleware: ClosureAuthenticator { _, _ in User(name: "stranger") })
             .get("items") { request, context -> [String] in
-                guard let identity = context.identity else { throw HTTPError(.unauthorized) }
-                let filter = try await scope.filter(for: identity, request: request)
-                var result: [String] = []
-                for item in allItems { if try await filter.matches(item) { result.append(item) } }
-                return result
+                let identity = try context.requireIdentity()
+                return
+                    try await allItems
+                    .filter(scope: scope, identity: identity, request: request)
             }
 
         let app = Application(responder: router.buildResponder())


### PR DESCRIPTION
AuthorizationPolicy answers a point query — *"can this identity see this specific resource?"* — and is the right tool for `GET /items/:id` routes. Collection routes (`GET /items`) need a complementary abstraction that answers *"given who you are, which resources can you see?"* and shapes the query before it runs, rather than blocking a single request.


Any backend — Fluent query modifier, OPA partial evaluation, Casbin filtered enforcement — implements `AuthorizationScope` and conforms `QueryFilter` without `HummingbirdAuth` knowing anything about the backend.