### PR TITLE
Load session time at load in SessionMiddleware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ let package = Package(
         .library(name: "HummingbirdAuthTesting", targets: ["HummingbirdAuthTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "get-with-ttl"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "HummingbirdAuthTesting", targets: ["HummingbirdAuthTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "get-with-ttl"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.25.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "1.0.0"),

--- a/Sources/HummingbirdAuth/Sessions/SessionContext.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionContext.swift
@@ -14,16 +14,38 @@ import NIOConcurrencyHelpers
 @dynamicMemberLookup
 public struct SessionData<Session: Sendable & Codable>: Codable, Sendable {
     @usableFromInline
+    struct EditedState: OptionSet, Sendable {
+        @usableFromInline
+        var rawValue: UInt8
+        @usableFromInline
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+        @usableFromInline
+        static var object: Self { .init(rawValue: 1 << 0) }
+        @usableFromInline
+        static var expires: Self { .init(rawValue: 1 << 1) }
+    }
+    @usableFromInline
     var object: Session
     @usableFromInline
-    var edited: Bool
+    var edited: EditedState
     /// When session will expire
-    public var expiresIn: Duration?
+    public var expiresIn: Duration? {
+        didSet { self.edited.insert(.expires) }
+    }
 
     @usableFromInline
     init(value: Session, expiresIn: Duration?) {
         self.object = value
-        self.edited = true
+        self.edited = expiresIn != nil ? [.object, .expires] : [.object]
+        self.expiresIn = expiresIn
+    }
+
+    @usableFromInline
+    init(value: Session, expiresIn: Duration?, edited: EditedState) {
+        self.object = value
+        self.edited = edited
         self.expiresIn = expiresIn
     }
 
@@ -31,7 +53,7 @@ public struct SessionData<Session: Sendable & Codable>: Codable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.object = try container.decode(Session.self)
-        self.edited = false
+        self.edited = []
         self.expiresIn = nil
     }
 
@@ -49,7 +71,7 @@ public struct SessionData<Session: Sendable & Codable>: Codable, Sendable {
         }
         set {
             self.object[keyPath: keyPath] = newValue
-            self.edited = true
+            self.edited.insert(.object)
         }
     }
 }

--- a/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
@@ -102,9 +102,10 @@ public struct SessionMiddleware<Context: SessionRequestContext>: RouterMiddlewar
     ///  Session Middleware handler
     public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
         var originalSessionData: Context.Session? = nil
+        var ttl: Duration? = nil
         var removeSession = false
         do {
-            originalSessionData = try await self.sessionStorage.load(request: request)
+            (originalSessionData, ttl) = try await self.sessionStorage.loadWithTTL(request: request)
         } catch let error as SessionStorage<Context.Session>.Error where error == .sessionInvalidType {
             context.logger.trace("Failed to convert session data")
             removeSession = true
@@ -114,18 +115,19 @@ public struct SessionMiddleware<Context: SessionRequestContext>: RouterMiddlewar
         if let originalSessionData {
             context.sessions.sessionData = SessionData(
                 value: originalSessionData,
-                expiresIn: nil
+                expiresIn: ttl,
+                edited: []
             )
         }
         var response = try await next(request, context)
         let sessionData = context.sessions.sessionData
         if let sessionData {
-            // if session has been edited then store new session
-            if sessionData.edited {
+            if !sessionData.edited.isEmpty {
                 do {
+                    let expiresIn = sessionData.edited.contains(.expires) ? sessionData.expiresIn : nil
                     if let cookie = try await self.sessionStorage.updateAndCreateCookie(
                         session: sessionData.object,
-                        expiresIn: sessionData.expiresIn,
+                        expiresIn: expiresIn,
                         request: request
                     ) {
                         response.headers[values: .setCookie].append(cookie.description)

--- a/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionMiddleware.swift
@@ -105,7 +105,10 @@ public struct SessionMiddleware<Context: SessionRequestContext>: RouterMiddlewar
         var ttl: Duration? = nil
         var removeSession = false
         do {
-            (originalSessionData, ttl) = try await self.sessionStorage.loadWithTTL(request: request)
+            if let session = try await self.sessionStorage.loadWithTTL(request: request) {
+                originalSessionData = session.session
+                ttl = session.ttl
+            }
         } catch let error as SessionStorage<Context.Session>.Error where error == .sessionInvalidType {
             context.logger.trace("Failed to convert session data")
             removeSession = true

--- a/Sources/HummingbirdAuth/Sessions/SessionStorage.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionStorage.swift
@@ -187,15 +187,17 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
 
     /// load session and time to live
     @inlinable
-    public func loadWithTTL(request: Request) async throws -> (session: SessionType?, ttl: Duration?) {
-        guard let sessionId = getId(request: request) else { return (nil, nil) }
+    public func loadWithTTL(request: Request) async throws -> (session: SessionType, ttl: Duration?)? {
+        guard let sessionId = getId(request: request) else { return nil }
         do {
             // prefix with key prefix
-            let (session, ttl) = try await self.storage.getWithTTL(
+            if let (session, ttl) = try await self.storage.getWithTTL(
                 key: "\(self.configuration.keyPrefix)\(sessionId)",
                 as: SessionType.self
-            )
-            return (session, ttl)
+            ) {
+                return (session, ttl)
+            }
+            return nil
         } catch let error as PersistError where error == .invalidConversion {
             throw Error.sessionInvalidType
         }

--- a/Sources/HummingbirdAuth/Sessions/SessionStorage.swift
+++ b/Sources/HummingbirdAuth/Sessions/SessionStorage.swift
@@ -70,7 +70,9 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
         public static var sessionInvalidType: Self { .init(.sessionInvalidType) }
     }
 
+    @usableFromInline
     let configuration: SessionStorageConfiguration
+    @usableFromInline
     let storage: any PersistDriver
 
     /// Initialize session storage
@@ -87,6 +89,7 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     ///   - storage: Session cookie storage
     ///   - sessionCookieParameters: Session cookie parameters
     @available(*, deprecated, renamed: "init(_:configuration:)")
+    @inlinable
     public init(
         _ storage: any PersistDriver,
         sessionCookieParameters: SessionCookieParameters
@@ -99,6 +102,7 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     /// - Parameters:
     ///   - storage: Session cookie storage
     ///   - configuration: Session storage configuration
+    @inlinable
     public init(
         _ storage: any PersistDriver,
         configuration: SessionStorageConfiguration
@@ -121,6 +125,7 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     /// ```
     /// If you know a session already exists it is preferable to use
     /// ``SessionStorage/update(session:expiresIn:request:)``.
+    @inlinable
     public func save(session: SessionType, expiresIn: Duration) async throws -> Cookie {
         let sessionId = Self.createSessionId()
         // prefix with key prefix
@@ -135,6 +140,7 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     /// update existing session
     ///
     /// If session does not exist then a `sessionDoesNotExist` error will be thrown
+    @inlinable
     public func update(session: SessionType, expiresIn: Duration?, request: Request) async throws {
         guard let sessionId = self.getId(request: request) else {
             throw Error.sessionDoesNotExist
@@ -165,6 +171,7 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     }
 
     /// load session
+    @inlinable
     public func load(request: Request) async throws -> SessionType? {
         guard let sessionId = getId(request: request) else { return nil }
         do {
@@ -178,9 +185,26 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
         }
     }
 
+    /// load session and time to live
+    @inlinable
+    public func loadWithTTL(request: Request) async throws -> (session: SessionType?, ttl: Duration?) {
+        guard let sessionId = getId(request: request) else { return (nil, nil) }
+        do {
+            // prefix with key prefix
+            let (session, ttl) = try await self.storage.getWithTTL(
+                key: "\(self.configuration.keyPrefix)\(sessionId)",
+                as: SessionType.self
+            )
+            return (session, ttl)
+        } catch let error as PersistError where error == .invalidConversion {
+            throw Error.sessionInvalidType
+        }
+    }
+
     /// Delete session
     /// - Parameter request: Request session is attached to
     /// - Returns: Expired cookie
+    @inlinable
     public func delete(request: Request) async throws -> Cookie {
         guard let sessionId = getId(request: request) else {
             throw Error.sessionDoesNotExist
@@ -193,17 +217,20 @@ public struct SessionStorage<SessionType: Codable>: Sendable {
     }
 
     /// Get session id gets id from request
+    @inlinable
     public func getId(request: Request) -> String? {
         guard let sessionCookie = request.cookies[self.configuration.sessionCookieParameters.name]?.value else { return nil }
         return String(sessionCookie)
     }
 
     /// create a session id
+    @usableFromInline
     static func createSessionId() -> String {
         let bytes: [UInt8] = (0..<32).map { _ in UInt8.random(in: 0...255) }
         return Base64.encodeToString(bytes: bytes)
     }
 
+    @usableFromInline
     func createSessionCookie(sessionId: String, expiresIn: Duration) -> Cookie {
         // accuracy of expires value in cookie only needs to be seconds
         let expires = Date.now + TimeInterval(expiresIn.components.seconds)

--- a/Tests/HummingbirdAuthTests/SessionTests.swift
+++ b/Tests/HummingbirdAuthTests/SessionTests.swift
@@ -131,8 +131,8 @@ struct SessionTests {
             return .ok
         }
         router.post("updateExpires") { request, context -> HTTPResponse.Status in
-            guard let name = request.uri.queryParameters.get("name") else { throw HTTPError(.badRequest) }
-            context.sessions.setSession(.init(name: name), expiresIn: .seconds(600))
+            guard let user = context.sessions.session else { throw HTTPError(.unauthorized) }
+            context.sessions.setSession(user, expiresIn: .seconds(600))
             return .ok
         }
         router.get("name") { _, context -> String in
@@ -156,7 +156,7 @@ struct SessionTests {
                 let buffer = response.body
                 #expect(String(buffer: buffer) == "jane")
             }
-            cookie = try await client.execute(uri: "/updateExpires?name=joan", method: .post, headers: [.cookie: cookie]) { response in
+            cookie = try await client.execute(uri: "/updateExpires", method: .post, headers: [.cookie: cookie]) { response in
                 #expect(response.status == .ok)
                 // if we update the cookie expiration date a set-cookie header should be returned
                 let newCookieHeader = try #require(response.headers[.setCookie])
@@ -170,7 +170,56 @@ struct SessionTests {
             try await client.execute(uri: "/name", method: .get, headers: [.cookie: cookie]) { response in
                 #expect(response.status == .ok)
                 let body = response.body
-                #expect(String(buffer: body) == "joan")
+                #expect(String(buffer: body) == "jane")
+            }
+        }
+    }
+
+    @Test func testSessiontTTL() async throws {
+        struct User: Codable, Sendable {
+            var name: String
+        }
+        let router = Router(context: BasicSessionRequestContext<User, User>.self)
+        let persist = MemoryPersistDriver()
+        router.add(middleware: SessionMiddleware(storage: persist))
+        router.post("save") { request, context -> HTTPResponse.Status in
+            guard
+                let name = request.uri.queryParameters.get("name")
+            else {
+                throw HTTPError(.badRequest)
+            }
+            context.sessions.setSession(User(name: name), expiresIn: .seconds(600))
+            return .ok
+        }
+        router.get("ttl") { request, context in
+            context.sessions.withLockedSession { $0.map { String($0.expiresIn?.components.seconds ?? -1) } ?? "No-session" }
+        }
+        router.post("updateExpires/{expire}") { request, context -> HTTPResponse.Status in
+            let expiresIn = try context.parameters.require("expire", as: Int.self)
+            context.sessions.withLockedSession { $0?.expiresIn = .seconds(expiresIn) }
+            return .ok
+        }
+        let app = Application(responder: router.buildResponder())
+
+        try await app.test(.router) { client in
+            let cookie = try await client.execute(uri: "/save?name=john", method: .post) { response -> String in
+                #expect(response.status == .ok)
+                return try #require(response.headers[.setCookie])
+            }
+            try await client.execute(uri: "/ttl", method: .get, headers: [.cookie: cookie]) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.setCookie] == nil)
+                let body = String(buffer: response.body)
+                #expect(body == "599")
+            }
+            try await client.execute(uri: "/updateExpires/70", method: .post, headers: [.cookie: cookie]) { response in
+                #expect(response.status == .ok)
+                #expect(response.headers[.setCookie] != nil)
+            }
+            try await client.execute(uri: "/ttl", method: .get, headers: [.cookie: cookie]) { response in
+                #expect(response.status == .ok)
+                let body = String(buffer: response.body)
+                #expect(body == "69")
             }
         }
     }

--- a/Tests/HummingbirdAuthTests/SessionTests.swift
+++ b/Tests/HummingbirdAuthTests/SessionTests.swift
@@ -209,8 +209,8 @@ struct SessionTests {
             try await client.execute(uri: "/ttl", method: .get, headers: [.cookie: cookie]) { response in
                 #expect(response.status == .ok)
                 #expect(response.headers[.setCookie] == nil)
-                let body = String(buffer: response.body)
-                #expect(body == "599")
+                let value = try #require(Int(String(buffer: response.body)))
+                #expect(value < 600 && value > 595)
             }
             try await client.execute(uri: "/updateExpires/70", method: .post, headers: [.cookie: cookie]) { response in
                 #expect(response.status == .ok)
@@ -218,8 +218,8 @@ struct SessionTests {
             }
             try await client.execute(uri: "/ttl", method: .get, headers: [.cookie: cookie]) { response in
                 #expect(response.status == .ok)
-                let body = String(buffer: response.body)
-                #expect(body == "69")
+                let value = try #require(Int(String(buffer: response.body)))
+                #expect(value < 70 && value > 65)
             }
         }
     }


### PR DESCRIPTION
- Use new persist driver `getWithTTL` command to get the session cookie time to live
- Previously we used the fact the expiresIn had been set to decide whether a set-cookie response header should be created. We can't do this anymore, so I had to change the edited bool to be a OptionSet which includes what has been edited. Session object being edited will update storage, expiresIn being edited will create set-cookie header